### PR TITLE
Display Existing Simulations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,11 @@
       <version>1.7.4</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
+    </dependency>
   </dependencies>
 
   <!-- todo: remove if not needed

--- a/src/main/java/com/google/research/bleth/servlets/ListSimulationsServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/ListSimulationsServlet.java
@@ -1,0 +1,33 @@
+package com.google.research.bleth.servlets;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.research.bleth.simulator.SimulationMetadata;
+
+import java.io.IOException;
+import java.util.HashMap;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** A servlet used for displaying simulations. */
+@WebServlet("/list-simulations")
+public class ListSimulationsServlet extends HttpServlet {
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        Gson gson = new Gson(); // Used for json serialization.
+
+        // Read SimulationMetadata as a HashMap.
+        HashMap<String, SimulationMetadata> simulations = SimulationMetadata.listSimulations();
+
+        // Serialize SimulationMetadata objects to JSON strings.
+        HashMap<String, JsonElement> simulationsAsJson = new HashMap<>();
+        simulations.forEach((id, metadata) -> simulationsAsJson.put(id, gson.toJsonTree(metadata)));
+
+        // Write hash map to response.
+        response.setContentType("application/json;");
+        response.getWriter().println(gson.toJson(simulationsAsJson));
+    }
+}

--- a/src/main/java/com/google/research/bleth/servlets/ListSimulationsServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/ListSimulationsServlet.java
@@ -1,5 +1,6 @@
 package com.google.research.bleth.servlets;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.research.bleth.simulator.SimulationMetadata;
@@ -20,7 +21,7 @@ public class ListSimulationsServlet extends HttpServlet {
         Gson gson = new Gson(); // Used for json serialization.
 
         // Read SimulationMetadata as a HashMap.
-        HashMap<String, SimulationMetadata> simulations = SimulationMetadata.listSimulations();
+        ImmutableMap<String, SimulationMetadata> simulations = SimulationMetadata.listSimulations();
 
         // Serialize SimulationMetadata objects to JSON strings.
         HashMap<String, JsonElement> simulationsAsJson = new HashMap<>();

--- a/src/main/java/com/google/research/bleth/simulator/SimulationMetadata.java
+++ b/src/main/java/com/google/research/bleth/simulator/SimulationMetadata.java
@@ -7,8 +7,7 @@ import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
-
-import java.util.HashMap;
+import com.google.common.collect.ImmutableMap;
 
 /** A class for storing, reading and writing simulation metadata. */
 public class SimulationMetadata {
@@ -97,15 +96,15 @@ public class SimulationMetadata {
      * Read all existing SimulationMetadata entites from the db, and return them as a hashmap.
      * @return a hashmap mapping a simulationId to the corresponding SimulationMetadata object.
      */
-    public static HashMap<String, SimulationMetadata> listSimulations() {
-        HashMap<String, SimulationMetadata> simulations = new HashMap<>();
+    public static ImmutableMap<String, SimulationMetadata> listSimulations() {
+        ImmutableMap.Builder<String, SimulationMetadata> simulations = new ImmutableMap.Builder<>();
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         Query simulationMetadataQuery = new Query(Schema.SimulationMetadata.entityKind);
         PreparedQuery simulationMetadataPreparedQuery = datastore.prepare(simulationMetadataQuery);
         for (Entity entity : simulationMetadataPreparedQuery.asIterable()) {
             simulations.put(KeyFactory.keyToString(entity.getKey()), new SimulationMetadata(entity));
         }
-        return simulations;
+        return simulations.build();
     }
 
     /** Return true if provided round exists in the simulation associated with the provided simulation id, and false otherwise. */

--- a/src/main/java/com/google/research/bleth/simulator/SimulationMetadata.java
+++ b/src/main/java/com/google/research/bleth/simulator/SimulationMetadata.java
@@ -8,6 +8,8 @@ import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 
+import java.util.HashMap;
+
 /** A class for storing, reading and writing simulation metadata. */
 public class SimulationMetadata {
     public final String type;
@@ -89,6 +91,21 @@ public class SimulationMetadata {
         PreparedQuery simulationIdPreparedQuery = datastore.prepare(simulationIdQuery);
         Entity simulationMetadataEntity = simulationIdPreparedQuery.asSingleEntity();
         return new SimulationMetadata(simulationMetadataEntity);
+    }
+
+    /**
+     * Read all existing SimulationMetadata entites from the db, and return them as a hashmap.
+     * @return a hashmap mapping a simulationId to the corresponding SimulationMetadata object.
+     */
+    public static HashMap<String, SimulationMetadata> listSimulations() {
+        HashMap<String, SimulationMetadata> simulations = new HashMap<>();
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        Query simulationMetadataQuery = new Query(Schema.SimulationMetadata.entityKind);
+        PreparedQuery simulationMetadataPreparedQuery = datastore.prepare(simulationMetadataQuery);
+        for (Entity entity : simulationMetadataPreparedQuery.asIterable()) {
+            simulations.put(KeyFactory.keyToString(entity.getKey()), new SimulationMetadata(entity));
+        }
+        return simulations;
     }
 
     /** Return true if provided round exists in the simulation associated with the provided simulation id, and false otherwise. */

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -7,12 +7,12 @@
 
   <!-- Servlet Mapping. -->
   <servlet>
-    <servlet-name>WelcomeMessageServlet</servlet-name>
-    <servlet-class>servlets.WelcomeMessageServlet</servlet-class>
+    <servlet-name>ListSimulationsServlet</servlet-name>
+    <servlet-class>com.google.research.bleth.servlets.ListSimulationsServlet</servlet-class>
   </servlet>
   <servlet-mapping>
-    <servlet-name>WelcomeMessageServlet</servlet-name>
-    <url-pattern>/welcome-msg</url-pattern>
+    <servlet-name>ListSimulationsServlet</servlet-name>
+    <url-pattern>/list-simulations</url-pattern>
   </servlet-mapping>
 
 </web-app>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -3,17 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <title>BLETH</title>
-    <script>
-        fetch('/welcome-msg').then(response => response.text()).then((text) => {
-        document.getElementById('welcome-text').innerText = text;
-        });
-    </script>
 </head>
 
 <body>
-<h1>BLETH 2020</h1>
-
-<h4><i id="welcome-text"></i></h4>
-<p>
+    <h1>BLETH 2020</h1>
 </body>
 </html>

--- a/src/main/webapp/simulations.html
+++ b/src/main/webapp/simulations.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>BLETH</title>
+    <script src='simulations.js'></script>
+</head>
+
+<body onload="retrieveSimulations()">
+    <h1>Choose a Simulation to Visualize</h1>
+    <table id="simulations-table"></table>
+</body>
+</html>

--- a/src/main/webapp/simulations.js
+++ b/src/main/webapp/simulations.js
@@ -61,8 +61,7 @@ function addSimulationRows(table, simulations) {
         row.insertCell(0).appendChild(visualizeSimulationButton);
         var i = 1; // cell index (cell 0 is a button).
         for (const property in simulation) {
-            row.insertCell(i).innerHTML = simulation[property];
-            i++;
+            row.insertCell(i++).innerHTML = simulation[property];
         }
     }
 }

--- a/src/main/webapp/simulations.js
+++ b/src/main/webapp/simulations.js
@@ -1,0 +1,68 @@
+/**
+ * Fetch url and retrieve a JSON object storing simulations' metadata,
+ * and display as an html table.
+ */
+function retrieveSimulations() {
+    fetch('/list-simulations')
+    .then(response => response.json())
+    .then(simulations => { 
+        displaySimulationAsTable(simulations); 
+    });
+}
+
+/**
+ * Given a json object storing simulations' metadata, write all data to an html table.
+ * @param simulations is an object storing simulations' unique id and metadata.
+ */
+function displaySimulationAsTable(simulations) {
+    const allSimulationIds = Object.keys(simulations);
+    if (allSimulationIds.length === 0) { return; }
+    
+    const firstSimulationId = allSimulationIds[0];
+    const firstSimulation = simulations[firstSimulationId];
+    const simulationProperties = Object.keys(firstSimulation);
+
+    var table = document.getElementById("simulations-table");
+    addSimulationHeader(table, simulationProperties);
+    addSimulationRows(table, simulations);
+}
+
+/**
+ * Given a table and an array of strings, add a header based on the array's items.
+ * @param table is the html table to be updated.
+ * @param properties is an array of header properties.
+ */
+function addSimulationHeader(table, properties) {
+    var header = table.createTHead();
+    var row = header.insertRow(0);
+    // cell 0 contains the simulation button, therefore header starts at cell 1.
+    row.insertCell(0).innerHTML = '';
+    for (var i = 0; i < properties.length; i++) {
+        row.insertCell(i + 1).innerHTML = properties[i];
+    }
+}
+
+/**
+ * Given a table and an object storing simulations' metadata, add a row for each simulation.
+ * @param table is the table to be updated.
+ * @param simulations is an object storing simulations' id and metadata.
+ */
+function addSimulationRows(table, simulations) {
+    for (const id in simulations) {
+        const simulation = simulations[id];
+        var row = table.insertRow(-1);
+        
+        var visualizeSimulationButton = document.createElement('button');
+        visualizeSimulationButton.innerText = 'Visualize Simulation';
+        visualizeSimulationButton.addEventListener('click', () => {
+            // todo: call a method for simulation visualizing.
+        });
+
+        row.insertCell(0).appendChild(visualizeSimulationButton);
+        var i = 1; // cell index (cell 0 is a button).
+        for (const property in simulation) {
+            row.insertCell(i).innerHTML = simulation[property];
+            i++;
+        }
+    }
+}


### PR DESCRIPTION
- Add a servlet for retrieving all existing simulation metadata entities.
- Add an html page and a js file for fetching this servlet and displaying all simulations' metadata in a table.
- This html page will be used for choosing a simulation to visualize. 

![image](https://user-images.githubusercontent.com/41709648/98681906-eecfca00-236b-11eb-9369-29ff61f3aa91.png)
(Not to worry - it will look better!)