### PR TITLE
Fix Agents' IDs Bag

### DIFF
--- a/src/main/java/com/google/research/bleth/simulator/BeaconFactory.java
+++ b/src/main/java/com/google/research/bleth/simulator/BeaconFactory.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 /** A factory class to create new beacons. */
 public class BeaconFactory {
-    static int beaconId = 0; // used for generating unique id for each beacon.
+    private int beaconId = 0; // used for generating unique id for each beacon.
 
     /**
      * Create new beacon, according to the given parameters.

--- a/src/main/java/com/google/research/bleth/simulator/ObserverFactory.java
+++ b/src/main/java/com/google/research/bleth/simulator/ObserverFactory.java
@@ -5,7 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 /** A factory class to create new observers. */
 public class ObserverFactory {
-    static int observerId = 0; // used for generating unique id for each observer.
+    private int observerId = 0; // used for generating unique id for each observer.
 
     /**
      * Create new observer, according to the given parameters.


### PR DESCRIPTION
Beacons' and observers' IDs starts now from 0 for each simulation, as expected.