### PR TITLE
Averaging Entities' Properties

### DIFF
--- a/src/main/java/com/google/research/bleth/utils/Queries.java
+++ b/src/main/java/com/google/research/bleth/utils/Queries.java
@@ -94,9 +94,6 @@ public class Queries {
      * @throws ClassCastException if property value cannot be casted to double (for some entity).
      */
     public static double Average(List<Entity> entities, String property) throws ClassCastException {
-        if (entities.isEmpty()) {
-            return Double.NaN;
-        }
         return entities.stream()
                 .filter(entity -> entity.hasProperty(property))
                 .mapToDouble(entity -> (double) entity.getProperty(property))
@@ -117,10 +114,6 @@ public class Queries {
         Map<String, Double> resultMap = new HashMap(); // Maintains the average for each property.
         Map<String, Integer> countersMap = new HashMap<>(); // Maintains the counter for each property.
         properties.forEach(property -> initializeMaps(resultMap, countersMap, property));
-        if (entities.isEmpty()) {
-            return resultMap;
-        }
-
         entities.forEach(entity -> updateMaps(resultMap, countersMap, properties, entity));
         return resultMap;
     }

--- a/src/main/java/com/google/research/bleth/utils/Queries.java
+++ b/src/main/java/com/google/research/bleth/utils/Queries.java
@@ -91,8 +91,9 @@ public class Queries {
      * @param entities is a list of entities.
      * @param property is the property to average.
      * @return The average value (or Nan if entities is empty or no entity with value exists).
+     * @throws ClassCastException if property value cannot be casted to double (for some entity).
      */
-    public static double Average(List<Entity> entities, String property) {
+    public static double Average(List<Entity> entities, String property) throws ClassCastException {
         if (entities.isEmpty()) {
             return Double.NaN;
         }
@@ -110,8 +111,9 @@ public class Queries {
      * @param properties is a list of properties.
      * @return a map where keys indicating properties' names and values indicating the averages (for each entry, Nan
      * value indicating no entity with property exists within entities list).
+     * @throws ClassCastException if one of properties values cannot be casted to double (for some entity).
      */
-    public static Map<String, Double> Average(List<Entity> entities, Set<String> properties) {
+    public static Map<String, Double> Average(List<Entity> entities, Set<String> properties) throws ClassCastException {
         Map<String, Double> resultMap = new HashMap(); // Maintains the average for each property.
         Map<String, Integer> countersMap = new HashMap<>(); // Maintains the counter for each property.
         properties.forEach(property -> initializeMaps(resultMap, countersMap, property));

--- a/src/main/java/com/google/research/bleth/utils/Queries.java
+++ b/src/main/java/com/google/research/bleth/utils/Queries.java
@@ -82,4 +82,21 @@ public class Queries {
 
         return result;
     }
+
+    /**
+     * Return the average of entities property value. Does not include entities which don't have property.
+     * @param entities is a list of entities.
+     * @param property is the property to average.
+     * @return The average value (or Nan if entities is empty or no entity with value exists).
+     */
+    public static double Average(List<Entity> entities, String property) {
+        if (entities.isEmpty()) {
+            return Double.NaN;
+        }
+        return entities.stream()
+                .filter(entity -> entity.hasProperty(property))
+                .mapToDouble(entity -> (double) entity.getProperty(property))
+                .average()
+                .orElse(Double.NaN);
+    }
 }

--- a/src/main/java/com/google/research/bleth/utils/Queries.java
+++ b/src/main/java/com/google/research/bleth/utils/Queries.java
@@ -111,7 +111,7 @@ public class Queries {
      * @throws ClassCastException if one of properties values cannot be casted to double (for some entity).
      */
     public static Map<String, Double> Average(List<Entity> entities, Set<String> properties) throws ClassCastException {
-        Map<String, Double> resultMap = new HashMap(); // Maintains the average for each property.
+        Map<String, Double> resultMap = new HashMap<>(); // Maintains the average for each property.
         Map<String, Integer> countersMap = new HashMap<>(); // Maintains the counter for each property.
         properties.forEach(property -> initializeMaps(resultMap, countersMap, property));
         entities.forEach(entity -> updateMaps(resultMap, countersMap, properties, entity));

--- a/src/main/java/com/google/research/bleth/utils/Queries.java
+++ b/src/main/java/com/google/research/bleth/utils/Queries.java
@@ -95,7 +95,7 @@ public class Queries {
      * @return The average value (or Nan if entities is empty or no entity with value exists).
      * @throws ClassCastException if property value cannot be casted to double (for some entity).
      */
-    public static double Average(List<Entity> entities, String property) throws ClassCastException {
+    public static double average(List<Entity> entities, String property) throws ClassCastException {
         return entities.stream()
                 .filter(entity -> entity.hasProperty(property))
                 .mapToDouble(entity -> (double) entity.getProperty(property))
@@ -112,8 +112,8 @@ public class Queries {
      * value indicating no entity with property exists within entities list).
      * @throws ClassCastException if one of properties values cannot be casted to double (for some entity).
      */
-    public static Map<String, Double> Average(List<Entity> entities, Set<String> properties) throws ClassCastException {
+    public static Map<String, Double> average(List<Entity> entities, Set<String> properties) throws ClassCastException {
         return properties.stream()
-                .collect(toImmutableMap(Function.identity(), property -> Average(entities, property)));
+                .collect(toImmutableMap(Function.identity(), property -> average(entities, property)));
     }
 }

--- a/src/main/java/com/google/research/bleth/utils/Queries.java
+++ b/src/main/java/com/google/research/bleth/utils/Queries.java
@@ -131,11 +131,10 @@ public class Queries {
                 int propertyCount = countersMap.get(property); // Property counter excluding current entity.
                 double propertyValue = (double) entity.getProperty(property);
                 if (propertyCount == 0) {
-                    // For the first occurrence of property, initialize counter as 1 and average of entity's value.
                     countersMap.put(property, 1);
                     resultMap.put(property, propertyValue);
                 } else {
-                    // Otherwise, restore previous sum using old counter and current average, and recompute the average.
+                    // Restore previous sum using old counter and current average, and recompute the average.
                     double currentAverage = resultMap.get(property);
                     countersMap.put(property, propertyCount + 1);
                     resultMap.put(property, (currentAverage * propertyCount + propertyValue) / (propertyCount + 1));

--- a/src/main/java/com/google/research/bleth/utils/Queries.java
+++ b/src/main/java/com/google/research/bleth/utils/Queries.java
@@ -9,12 +9,13 @@ import com.google.appengine.api.datastore.Query;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /** A utility class providing method for db related operations, such as join and group by. */
 public class Queries {
@@ -112,16 +113,14 @@ public class Queries {
      * @throws ClassCastException if one of properties values cannot be casted to double (for some entity).
      */
     public static Map<String, Double> Average(List<Entity> entities, Set<String> properties) throws ClassCastException {
-        Map<String, Double> resultMap = new HashMap<>(); // Maintains the average for each property.
-        Map<String, Integer> countersMap = new HashMap<>(); // Maintains the counter for each property.
-        properties.forEach(property -> initializeMaps(resultMap, countersMap, property));
+        // Maintains the average for each property.
+        Map<String, Double> resultMap =
+                properties.stream().collect(Collectors.toMap(Function.identity(), p -> Double.NaN));
+        // Maintains the counter for each property.
+        Map<String, Integer> countersMap =
+                properties.stream().collect(Collectors.toMap(Function.identity(), p -> 0));
         entities.forEach(entity -> updateMaps(resultMap, countersMap, properties, entity));
         return ImmutableMap.copyOf(resultMap);
-    }
-
-    private static void initializeMaps(Map<String, Double> resultMap, Map<String, Integer> countersMap, String property) {
-        resultMap.put(property, Double.NaN);
-        countersMap.put(property, 0);
     }
 
     private static void updateMaps(Map<String, Double> resultMap, Map<String, Integer> countersMap,

--- a/src/main/java/com/google/research/bleth/utils/Queries.java
+++ b/src/main/java/com/google/research/bleth/utils/Queries.java
@@ -6,6 +6,7 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.Query;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -115,7 +116,7 @@ public class Queries {
         Map<String, Integer> countersMap = new HashMap<>(); // Maintains the counter for each property.
         properties.forEach(property -> initializeMaps(resultMap, countersMap, property));
         entities.forEach(entity -> updateMaps(resultMap, countersMap, properties, entity));
-        return resultMap;
+        return ImmutableMap.copyOf(resultMap);
     }
 
     private static void initializeMaps(Map<String, Double> resultMap, Map<String, Integer> countersMap, String property) {

--- a/src/test/java/com/google/research/bleth/utils/QueriesIT.java
+++ b/src/test/java/com/google/research/bleth/utils/QueriesIT.java
@@ -385,7 +385,7 @@ public class QueriesIT {
         List<Entity> entities = retrieveEntities(ENTITY_KIND);
         double expectedAverage = 2.0;
 
-        double actualAverage = Queries.Average(entities, EXISTING_PROPERTY);
+        double actualAverage = Queries.average(entities, EXISTING_PROPERTY);
 
         assertThat(actualAverage).isEqualTo(expectedAverage);
     }
@@ -398,7 +398,7 @@ public class QueriesIT {
         List<Entity> entities = retrieveEntities(ENTITY_KIND);
         double expectedAverage = 1.0;
 
-        double actualAverage = Queries.Average(entities, EXISTING_PROPERTY);
+        double actualAverage = Queries.average(entities, EXISTING_PROPERTY);
 
         assertThat(actualAverage).isEqualTo(expectedAverage);
     }
@@ -408,7 +408,7 @@ public class QueriesIT {
         List<Entity> entities = retrieveEntities(ENTITY_KIND);
         double expectedAverage = Double.NaN;
 
-        double actualAverage = Queries.Average(entities, EXISTING_PROPERTY);
+        double actualAverage = Queries.average(entities, EXISTING_PROPERTY);
 
         assertThat(actualAverage).isEqualTo(expectedAverage);
     }
@@ -419,7 +419,7 @@ public class QueriesIT {
         List<Entity> entities = retrieveEntities(ENTITY_KIND);
         double expectedAverage = Double.NaN;
 
-        double actualAverage = Queries.Average(entities, EXISTING_PROPERTY);
+        double actualAverage = Queries.average(entities, EXISTING_PROPERTY);
 
         assertThat(actualAverage).isEqualTo(expectedAverage);
     }
@@ -429,7 +429,7 @@ public class QueriesIT {
         writeEntityWithStringProperty(ENTITY_KIND, EXISTING_PROPERTY, "notCastable");
         List<Entity> entities = retrieveEntities(ENTITY_KIND);
 
-        assertThrows(ClassCastException.class, () -> Queries.Average(entities, EXISTING_PROPERTY));
+        assertThrows(ClassCastException.class, () -> Queries.average(entities, EXISTING_PROPERTY));
     }
 
     // Multiple-properties Aggregation Test Cases.
@@ -462,7 +462,7 @@ public class QueriesIT {
         expectedResult.put(PROPERTY_B, 1.5);
         expectedResult.put(PROPERTY_C, 2.0);
 
-        Map<String, Double> actualResult = Queries.Average(entities, properties);
+        Map<String, Double> actualResult = Queries.average(entities, properties);
 
         assertThat(actualResult).containsExactlyEntriesIn(expectedResult);
     }
@@ -491,7 +491,7 @@ public class QueriesIT {
         expectedResult.put(PROPERTY_B, 1.5);
         expectedResult.put(PROPERTY_C, Double.NaN);
 
-        Map<String, Double> actualResult = Queries.Average(entities, properties);
+        Map<String, Double> actualResult = Queries.average(entities, properties);
 
         assertThat(actualResult).containsExactlyEntriesIn(expectedResult);
     }

--- a/src/test/java/com/google/research/bleth/utils/QueriesIT.java
+++ b/src/test/java/com/google/research/bleth/utils/QueriesIT.java
@@ -1,6 +1,7 @@
 package com.google.research.bleth.utils;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -418,6 +419,14 @@ public class QueriesIT {
         assertThat(actualAverage).isEqualTo(expectedAverage);
     }
 
+    @Test
+    public void writeEntityWithNonDoubleCastableProperty_shouldThrowException() {
+        writeEntityWithStringProperty(ENTITY_KIND, EXISTING_PROPERTY, "notCastable");
+        List<Entity> entities = retrieveEntities(ENTITY_KIND);
+
+        assertThrows(ClassCastException.class, () -> Queries.Average(entities, EXISTING_PROPERTY));
+    }
+
     // Multiple-properties Aggregation Test Cases.
 
     @Test
@@ -510,6 +519,13 @@ public class QueriesIT {
     private void writeEntityWithoutProperty(String entityKind) {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         Entity entity = new Entity(entityKind);
+        datastore.put(entity);
+    }
+
+    private void writeEntityWithStringProperty(String entityKind, String property, String value) {
+        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+        Entity entity = new Entity(entityKind);
+        entity.setProperty(property, value);
         datastore.put(entity);
     }
 

--- a/src/test/java/com/google/research/bleth/utils/QueriesIT.java
+++ b/src/test/java/com/google/research/bleth/utils/QueriesIT.java
@@ -50,6 +50,11 @@ public class QueriesIT {
         helper.setUp();
     }
 
+    @After
+    public void tearDown() {
+        helper.tearDown();
+    }
+
     // Join Test Cases.
 
     @Test
@@ -489,11 +494,6 @@ public class QueriesIT {
         Map<String, Double> actualResult = Queries.Average(entities, properties);
 
         assertThat(actualResult).containsExactlyEntriesIn(expectedResult);
-    }
-
-    @After
-    public void tearDown() {
-        helper.tearDown();
     }
 
     private void writeEntityWithProperty(String entityKind, String property, double value) {

--- a/src/test/java/com/google/research/bleth/utils/QueriesIT.java
+++ b/src/test/java/com/google/research/bleth/utils/QueriesIT.java
@@ -459,9 +459,7 @@ public class QueriesIT {
 
         Map<String, Double> actualResult = Queries.Average(entities, properties);
 
-        for (String property : properties) {
-            assertThat(actualResult.get(property)).isEqualTo(expectedResult.get(property));
-        }
+        assertThat(actualResult).containsExactlyEntriesIn(expectedResult);
     }
 
     @Test
@@ -490,9 +488,7 @@ public class QueriesIT {
 
         Map<String, Double> actualResult = Queries.Average(entities, properties);
 
-        for (String property : properties) {
-            assertThat(actualResult.get(property)).isEqualTo(expectedResult.get(property));
-        }
+        assertThat(actualResult).containsExactlyEntriesIn(expectedResult);
     }
 
     @After


### PR DESCRIPTION
Implemented methods for averaging entities' properties:
* A method for calculating the average of list of entities over a single property - this returns the average value.
* A method for calculating the averages of list of entities over a **set** of properties - this return a map where the key indicates the property and the value is the average value of this property.

These method will be used for providing statistical data over multiple simulation.