### PR TITLE
Delete Simulation Button

### DIFF
--- a/src/main/java/com/google/research/bleth/servlets/DeleteSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/DeleteSimulationServlet.java
@@ -21,7 +21,7 @@ public class DeleteSimulationServlet extends HttpServlet {
         } catch (Exception e) {
             responseText = "Something went wrong: " + e.getMessage();
         }
-        response.setContentType("text/html;");
+        response.setContentType("text/plain;");
         response.getWriter().println(responseText);
     }
 }

--- a/src/main/java/com/google/research/bleth/servlets/DeleteSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/DeleteSimulationServlet.java
@@ -15,8 +15,13 @@ public class DeleteSimulationServlet extends HttpServlet {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         String simulationId = request.getParameter("simulationId");
-        Queries.delete(simulationId);
+        String responseText = "Simulation has been deleted successfully.";
+        try {
+            Queries.delete(simulationId);
+        } catch (Exception e) {
+            responseText = "Something went wrong: " + e.getMessage();
+        }
         response.setContentType("text/html;");
-        response.getWriter().println("Simulation has been deleted successfully.");
+        response.getWriter().println(responseText);
     }
 }

--- a/src/main/java/com/google/research/bleth/servlets/DeleteSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/DeleteSimulationServlet.java
@@ -1,0 +1,22 @@
+package com.google.research.bleth.servlets;
+
+import com.google.research.bleth.utils.Queries;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** A servlet used for deleting simulations. */
+@WebServlet("/delete-simulation")
+public class DeleteSimulationServlet extends HttpServlet {
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String simulationId = request.getParameter("simulationId");
+        Queries.delete(simulationId);
+        response.setContentType("text/html;");
+        response.getWriter().println("Simulation has been deleted successfully.");
+    }
+}

--- a/src/main/java/com/google/research/bleth/servlets/NewSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/NewSimulationServlet.java
@@ -63,7 +63,7 @@ public class NewSimulationServlet extends HttpServlet {
         }
 
         // Write to response.
-        response.setContentType("text/html;");
+        response.setContentType("text/plain;");
         response.getWriter().println(responseText);
     }
 }

--- a/src/main/java/com/google/research/bleth/utils/Queries.java
+++ b/src/main/java/com/google/research/bleth/utils/Queries.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
-/** A utility class providing method for db related operations, such as join and group by. */
+/** A utility class providing method for db related operations. */
 public class Queries {
     private static DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 

--- a/src/main/java/com/google/research/bleth/utils/Queries.java
+++ b/src/main/java/com/google/research/bleth/utils/Queries.java
@@ -131,9 +131,9 @@ public class Queries {
         datastore.delete(KeyFactory.stringToKey(simulationId));
     }
 
-    private static void delete(String entityKind, String forgeinKeyProperty, String forgeinKeyValue) {
+    private static void delete(String entityKind, String foreignKeyProperty, String foreignKeyKeyValue) {
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-        Query.Filter filter = new Query.FilterPredicate(forgeinKeyProperty, Query.FilterOperator.EQUAL, forgeinKeyValue);
+        Query.Filter filter = new Query.FilterPredicate(foreignKeyProperty, Query.FilterOperator.EQUAL, foreignKeyKeyValue);
         Query entitiesToDelete = new Query(entityKind).setFilter(filter);
         Iterable<Entity> entitiesToDeleteIterable = datastore.prepare(entitiesToDelete).asIterable();
         for (Entity entity : entitiesToDeleteIterable) {

--- a/src/main/java/com/google/research/bleth/utils/Queries.java
+++ b/src/main/java/com/google/research/bleth/utils/Queries.java
@@ -20,6 +20,7 @@ import java.util.function.Function;
 
 /** A utility class providing method for db related operations, such as join and group by. */
 public class Queries {
+    private static DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     /**
      * Given a primary entity kind, a secondary entity kind, a foreign key and a filter, return a list of all entities
@@ -40,7 +41,6 @@ public class Queries {
      */
     public static List<Entity> join(String primaryEntityKind, String secondaryEntityKind,
                                     String foreignKey, Optional<Query.Filter> primaryEntityFilter) {
-        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         List<Entity> result = new ArrayList<>();
 
         // Retrieve all primaryEntity keys ordered by their key, filtered by primaryEntityFilter (if provided).
@@ -123,7 +123,6 @@ public class Queries {
      * @param simulationId is the simulation id.
      */
     public static void delete(String simulationId) {
-        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         delete(Schema.StatisticsState.entityKindBeaconsObservedPercent, Schema.StatisticsState.simulationId, simulationId);
         delete(Schema.StatisticsState.entityKindDistance, Schema.StatisticsState.simulationId, simulationId);
         delete(Schema.BoardState.entityKindReal, Schema.BoardState.simulationId, simulationId);
@@ -132,7 +131,6 @@ public class Queries {
     }
 
     private static void delete(String entityKind, String foreignKeyProperty, String foreignKeyKeyValue) {
-        DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         Query.Filter filter = new Query.FilterPredicate(foreignKeyProperty, Query.FilterOperator.EQUAL, foreignKeyKeyValue);
         Query entitiesToDelete = new Query(entityKind).setFilter(filter);
         Iterable<Entity> entitiesToDeleteIterable = datastore.prepare(entitiesToDelete).asIterable();

--- a/src/main/java/com/google/research/bleth/utils/Queries.java
+++ b/src/main/java/com/google/research/bleth/utils/Queries.java
@@ -8,6 +8,7 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.Query;
+import com.google.common.collect.Iterables;
 import com.google.research.bleth.simulator.Schema;
 
 import java.util.ArrayList;
@@ -134,8 +135,6 @@ public class Queries {
         Query.Filter filter = new Query.FilterPredicate(foreignKeyProperty, Query.FilterOperator.EQUAL, foreignKeyKeyValue);
         Query entitiesToDelete = new Query(entityKind).setFilter(filter);
         Iterable<Entity> entitiesToDeleteIterable = datastore.prepare(entitiesToDelete).asIterable();
-        for (Entity entity : entitiesToDeleteIterable) {
-            datastore.delete(entity.getKey());
-        }
+        datastore.delete(Iterables.transform(entitiesToDeleteIterable, Entity::getKey));
     }
 }

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -22,6 +22,10 @@
         <servlet-name>ListSimulationsServlet</servlet-name>
         <servlet-class>com.google.research.bleth.servlets.ListSimulationsServlet</servlet-class>
     </servlet>
+    <servlet>
+        <servlet-name>DeleteSimulationServlet</servlet-name>
+        <servlet-class>com.google.research.bleth.servlets.DeleteSimulationServlet</servlet-class>
+    </servlet>
 
     <servlet-mapping>
         <servlet-name>ReadBoardStateServlet</servlet-name>
@@ -38,6 +42,10 @@
     <servlet-mapping>
         <servlet-name>ListSimulationsServlet</servlet-name>
         <url-pattern>/list-simulations</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>DeleteSimulationServlet</servlet-name>
+        <url-pattern>/delete-simulation</url-pattern>
     </servlet-mapping>
 
 </web-app>

--- a/src/main/webapp/js/simulations.js
+++ b/src/main/webapp/js/simulations.js
@@ -55,26 +55,53 @@ function addSimulationRows(table, simulations) {
     for (const id in simulations) {
         const simulation = simulations[id];
         var row = table.insertRow(-1);
-        
-        var visualizeSimulationButton = document.createElement('button');
-        visualizeSimulationButton.innerText = 'Visualize Simulation';
-        /**
-         * For each simulation add a button redirecting to simulation_visualization.html
-         * Simulation metadata is encoded as a query string.
-         */
-        visualizeSimulationButton.addEventListener('click', () => {
-            // Create a deep copy of simulation JSON, and the simulation id as a new key.
-            var simulationWithId = JSON.parse(JSON.stringify(simulation));
-            simulationWithId['id'] = id;
-            
-            // Redirect.
-            window.location.replace('simulation_visualization.html?' + toQueryString(simulationWithId));
-        });
-
-        row.insertCell(0).appendChild(visualizeSimulationButton);
+        const visualizeSimulationButton = createVisualizationButton(simulation, id);
+        const deleteSimulationButton = createDeletionButton(id);
+        const cell = row.insertCell(0);
+        cell.appendChild(visualizeSimulationButton);
+        cell.appendChild(deleteSimulationButton);
         var i = 1; // cell index (cell 0 is a button).
         for (const property in simulation) {
             row.insertCell(i++).innerHTML = simulation[property];
         }
     }
+}
+
+/**
+ * Create a button for simulation visualization.
+ * @param {Object} simulation is the simulation object.
+ * @param {String} id is the simulation id. 
+ */
+function createVisualizationButton(simulation, id) {
+    var visualizeSimulationButton = document.createElement('button');
+    visualizeSimulationButton.innerText = 'Visualize Simulation';
+    visualizeSimulationButton.addEventListener('click', () => {
+        var simulationWithId = JSON.parse(JSON.stringify(simulation)); // Deep copy.
+        simulationWithId['id'] = id;
+        window.location.replace('simulation_visualization.html?' + toQueryString(simulationWithId));
+    });
+
+    return visualizeSimulationButton;
+}
+
+/**
+ * Create a button for simulation deletion.
+ * @param {String} id is the simulation id. 
+ */
+function createDeletionButton(id) {
+    var deleteSimulationButton = document.createElement('button');
+    deleteSimulationButton.innerText = 'Delete Simulation';
+    deleteSimulationButton.addEventListener('click', () => {
+        var confirmed = confirm('Do you want to delete this simulation?');
+        if (confirmed) {
+            var params = new URLSearchParams();
+            params.append('simulationId', id);
+            fetch('/delete-simulation', {method: 'POST', body: params})
+            .then(response => response.text())
+            .then(message => window.alert(message))
+            .then(() => location.reload())
+        }
+    });
+
+    return deleteSimulationButton;
 }


### PR DESCRIPTION
Added a button for deleting a simulation from the db, by deleting all entities associated with its id (metadata, board states and stats).
![image](https://user-images.githubusercontent.com/41709648/100552598-f4e10880-3290-11eb-90cd-d92871837925.png)