### PR TITLE
Tasks Queue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-tasks</artifactId>
+      <version>1.3.0</version>
+    </dependency>
   </dependencies>
 
   <!-- todo: remove if not needed

--- a/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
@@ -46,7 +46,7 @@ public class EnqueueSimulationServlet extends HttpServlet {
             client.createTask(queueName, task);
         }
 
-        response.setContentType("text/html;");
+        response.setContentType("text/plain;");
         response.getWriter().println("Task has been added to queue.");
     }
 

--- a/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
@@ -14,6 +14,10 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+/**
+ * A servlet used for enqueuing a task targeted at endpoint '/new-simulation',
+ * in order to create and run a new simulation.
+ */
 @WebServlet("/enqueue-simulation")
 public class EnqueueSimulationServlet extends HttpServlet {
 

--- a/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
@@ -33,28 +33,29 @@ public class EnqueueSimulationServlet extends HttpServlet {
             RequestDispatcher dispatcher = getServletContext()
                     .getRequestDispatcher("/new-simulation");
             dispatcher.forward(request, response);
-        } else {
-            try (CloudTasksClient client = CloudTasksClient.create()) {
-                // Construct the HTTP request (for the task).
-                AppEngineHttpRequest httpRequest = AppEngineHttpRequest.newBuilder()
-                        .setRelativeUri("/new-simulation")
-                        .setHttpMethod(HttpMethod.POST)
-                        .putHeaders("Content-Type", request.getContentType())
-                        .setBody(ByteString.readFrom(request.getInputStream()))
-                        .build();
-
-                // Construct the task body.
-                Task task = Task.newBuilder()
-                        .setAppEngineHttpRequest(httpRequest)
-                        .build();
-
-                // Add the task to the queue.
-                String queueName = QueueName.of(PROJECT_ID, LOCATION_ID, QUEUE_ID).toString();
-                client.createTask(queueName, task);
-            }
-
-            response.setContentType("text/plain;");
-            response.getWriter().println("Task has been added to queue.");
+            return;
         }
+
+        try (CloudTasksClient client = CloudTasksClient.create()) {
+            // Construct the HTTP request (for the task).
+            AppEngineHttpRequest httpRequest = AppEngineHttpRequest.newBuilder()
+                    .setRelativeUri("/new-simulation")
+                    .setHttpMethod(HttpMethod.POST)
+                    .putHeaders("Content-Type", request.getContentType())
+                    .setBody(ByteString.readFrom(request.getInputStream()))
+                    .build();
+
+            // Construct the task body.
+            Task task = Task.newBuilder()
+                    .setAppEngineHttpRequest(httpRequest)
+                    .build();
+
+            // Add the task to the queue.
+            String queueName = QueueName.of(PROJECT_ID, LOCATION_ID, QUEUE_ID).toString();
+            client.createTask(queueName, task);
+        }
+
+        response.setContentType("text/plain;");
+        response.getWriter().println("Task has been added to queue.");
     }
 }

--- a/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
@@ -7,6 +7,8 @@ import com.google.cloud.tasks.v2.QueueName;
 import com.google.cloud.tasks.v2.Task;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -39,14 +41,15 @@ public class EnqueueSimulationServlet extends HttpServlet {
             client.createTask(queueName, task);
         }
 
-        response.sendRedirect("/");
+        response.setContentType("text/html;");
+        response.getWriter().println("Task has been added to queue.");
     }
 
     private String toQueryString(HttpServletRequest request) {
-        StringBuilder queryString = new StringBuilder();
+        List<String> keyValuePairs = new ArrayList<>();
         for (String param : request.getParameterMap().keySet()) {
-            queryString.append(param).append("=").append(request.getParameter(param));
+            keyValuePairs.add(param + "=" + request.getParameter(param));
         }
-        return queryString.toString();
+        return String.join("&", keyValuePairs);
     }
 }

--- a/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
@@ -21,16 +21,14 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/enqueue-simulation")
 public class EnqueueSimulationServlet extends HttpServlet {
 
-    static final String projectId = "bleth-2020";
-    static final String locationId = "europe-west1";
-    static final String queueId = "simulations-queue";
+    static final String PROJECT_ID = "bleth-2020";
+    static final String LOCATION_ID = "europe-west1";
+    static final String QUEUE_ID = "simulations-queue";
+    static final String QUEUE_NAME = QueueName.of(PROJECT_ID, LOCATION_ID, QUEUE_ID).toString();
 
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
         try (CloudTasksClient client = CloudTasksClient.create()) {
-            // Construct the fully qualified queue name.
-            String queueName = QueueName.of(projectId, locationId, queueId).toString();
-
             // Construct the HTTP request (for the task).
             AppEngineHttpRequest httpRequest = AppEngineHttpRequest.newBuilder()
                     .setRelativeUri("/new-simulation?" + toQueryString(request))
@@ -43,7 +41,7 @@ public class EnqueueSimulationServlet extends HttpServlet {
                     .build();
 
             // Add the task to the queue.
-            client.createTask(queueName, task);
+            client.createTask(QUEUE_NAME, task);
         }
 
         response.setContentType("text/plain;");

--- a/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
@@ -27,15 +27,16 @@ public class EnqueueSimulationServlet extends HttpServlet {
             // Construct the fully qualified queue name.
             String queueName = QueueName.of(projectId, locationId, queueId).toString();
 
+            // Construct the HTTP request (for the task).
+            AppEngineHttpRequest httpRequest = AppEngineHttpRequest.newBuilder()
+                    .setRelativeUri("/new-simulation?" + toQueryString(request))
+                    .setHttpMethod(HttpMethod.POST)
+                    .build();
+
             // Construct the task body.
-            Task task =
-                    Task.newBuilder()
-                            .setAppEngineHttpRequest(
-                                    AppEngineHttpRequest.newBuilder()
-                                            .setRelativeUri("/new-simulation?" + toQueryString(request))
-                                            .setHttpMethod(HttpMethod.POST)
-                                            .build())
-                            .build();
+            Task task = Task.newBuilder()
+                    .setAppEngineHttpRequest(httpRequest)
+                    .build();
 
             // Add the task to the queue.
             client.createTask(queueName, task);

--- a/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
@@ -49,8 +49,8 @@ public class EnqueueSimulationServlet extends HttpServlet {
                         .build();
 
                 // Add the task to the queue.
-                String QUEUE_NAME = QueueName.of(PROJECT_ID, LOCATION_ID, QUEUE_ID).toString();
-                client.createTask(QUEUE_NAME, task);
+                String queueName = QueueName.of(PROJECT_ID, LOCATION_ID, QUEUE_ID).toString();
+                client.createTask(queueName, task);
             }
 
             response.setContentType("text/plain;");

--- a/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
@@ -12,7 +12,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@WebServlet("enqueue-simulation")
+@WebServlet("/enqueue-simulation")
 public class EnqueueSimulationServlet extends HttpServlet {
 
     static final String projectId = "bleth-2020";

--- a/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
@@ -25,7 +25,6 @@ public class EnqueueSimulationServlet extends HttpServlet {
     static final String PROJECT_ID = "bleth-2020";
     static final String LOCATION_ID = "europe-west1";
     static final String QUEUE_ID = "simulations-queue";
-    //static final String QUEUE_NAME = QueueName.of(PROJECT_ID, LOCATION_ID, QUEUE_ID).toString();
 
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
 

--- a/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/EnqueueSimulationServlet.java
@@ -1,0 +1,52 @@
+package com.google.research.bleth.servlets;
+
+import com.google.cloud.tasks.v2.AppEngineHttpRequest;
+import com.google.cloud.tasks.v2.CloudTasksClient;
+import com.google.cloud.tasks.v2.HttpMethod;
+import com.google.cloud.tasks.v2.QueueName;
+import com.google.cloud.tasks.v2.Task;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("enqueue-simulation")
+public class EnqueueSimulationServlet extends HttpServlet {
+
+    static final String projectId = "bleth-2020";
+    static final String locationId = "europe-west1";
+    static final String queueId = "simulations-queue";
+
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        try (CloudTasksClient client = CloudTasksClient.create()) {
+            // Construct the fully qualified queue name.
+            String queueName = QueueName.of(projectId, locationId, queueId).toString();
+
+            // Construct the task body.
+            Task task =
+                    Task.newBuilder()
+                            .setAppEngineHttpRequest(
+                                    AppEngineHttpRequest.newBuilder()
+                                            .setRelativeUri("/new-simulation?" + toQueryString(request))
+                                            .setHttpMethod(HttpMethod.POST)
+                                            .build())
+                            .build();
+
+            // Add the task to the queue.
+            client.createTask(queueName, task);
+        }
+
+        response.sendRedirect("/");
+    }
+
+    private String toQueryString(HttpServletRequest request) {
+        StringBuilder queryString = new StringBuilder();
+        for (String param : request.getParameterMap().keySet()) {
+            queryString.append(param).append("=").append(request.getParameter(param));
+        }
+        return queryString.toString();
+    }
+}

--- a/src/main/java/com/google/research/bleth/servlets/NewSimulationServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/NewSimulationServlet.java
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+/** A servlet used for creating and running a new simulation. */
 @WebServlet("/new-simulation")
 public class NewSimulationServlet extends HttpServlet {
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -22,6 +22,10 @@
         <servlet-name>ListSimulationsServlet</servlet-name>
         <servlet-class>com.google.research.bleth.servlets.ListSimulationsServlet</servlet-class>
     </servlet>
+    <servlet>
+        <servlet-name>EnqueueSimulationServlet</servlet-name>
+        <servlet-class>com.google.research.bleth.servlets.EnqueueSimulationServlet</servlet-class>
+    </servlet>
 
     <servlet-mapping>
         <servlet-name>ReadBoardStateServlet</servlet-name>
@@ -38,6 +42,10 @@
     <servlet-mapping>
         <servlet-name>ListSimulationsServlet</servlet-name>
         <url-pattern>/list-simulations</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>EnqueueSimulationServlet</servlet-name>
+        <url-pattern>/enqueue-simulation</url-pattern>
     </servlet-mapping>
 
 </web-app>

--- a/src/main/webapp/js/new_simulation.js
+++ b/src/main/webapp/js/new_simulation.js
@@ -123,7 +123,7 @@ function createNewSimulation() {
     // If confirmed, fetch url to create and run a new simulation.
     var confirmed = confirm("Create and run a new simulation?")
     if (confirmed) {
-        fetch('/new-simulation', {method: 'POST', body: params})
+        fetch('/enqueue-simulation', {method: 'POST', body: params})
         .then(response => response.text())
         .then(message => window.alert(message));
     }


### PR DESCRIPTION
Implemented a servlet to receive POST request from client and enqueue a task into `simulations-queue`.
This lead to the following performance improvements:
* A 25*25 simulations runs for about 500 rounds.
* A 50*50 simulations runs for about 150 rounds. 

To be done next:
* Configure tasks queue timeout (currently 10 mins).
* Wrap simulation build and run in a single transaction.
* Limit number of rounds in the new simulation form.