### PR TITLE
Basic Scaling

### DIFF
--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -7,4 +7,8 @@
         <!-- prevent unwanted caching when accessing via the web preview server -->
         <include path="/**" expiration="0s" />
     </static-files>
+    <basic-scaling>
+        <max-instances>4</max-instances>
+        <idle-timeout>10m</idle-timeout>
+    </basic-scaling>
 </appengine-web-app>


### PR DESCRIPTION
* 4 maximum instances, 10 minutes instance idle timeout.
* 24 hours requests timeout for HTTP request and task queue tasks.