### PR TITLE
Join Implementation Bug Fix

### DIFF
--- a/src/main/java/com/google/research/bleth/utils/Queries.java
+++ b/src/main/java/com/google/research/bleth/utils/Queries.java
@@ -98,7 +98,18 @@ public class Queries {
             }
         }
 
-        // Add last entity to result (if matching).
+        // Add remaining secondary entities to result (if matching).
+        while (secondaryEntityIterator.hasNext()) {
+            if (primaryKey.compareTo(secondaryKey) > 0) {
+                secondaryEntity = secondaryEntityIterator.next();
+                secondaryKey = (String) secondaryEntity.getProperty(foreignKey);
+            } else if (primaryKey.compareTo(secondaryKey) == 0) {
+                result.add(secondaryEntity);
+                secondaryEntity = secondaryEntityIterator.next();
+                secondaryKey = (String) secondaryEntity.getProperty(foreignKey);
+                break;
+            }
+        }
         if (primaryKey.compareTo(secondaryKey) == 0) {
             result.add(secondaryEntity);
         }

--- a/src/main/java/com/google/research/bleth/utils/Queries.java
+++ b/src/main/java/com/google/research/bleth/utils/Queries.java
@@ -99,16 +99,12 @@ public class Queries {
         }
 
         // Add remaining secondary entities to result (if matching).
-        while (secondaryEntityIterator.hasNext()) {
-            if (primaryKey.compareTo(secondaryKey) > 0) {
-                secondaryEntity = secondaryEntityIterator.next();
-                secondaryKey = (String) secondaryEntity.getProperty(foreignKey);
-            } else if (primaryKey.compareTo(secondaryKey) == 0) {
+        while (secondaryEntityIterator.hasNext() && (primaryKey.compareTo(secondaryKey) >= 0)) {
+            if (primaryKey.compareTo(secondaryKey) == 0) {
                 result.add(secondaryEntity);
-                secondaryEntity = secondaryEntityIterator.next();
-                secondaryKey = (String) secondaryEntity.getProperty(foreignKey);
-                break;
             }
+            secondaryEntity = secondaryEntityIterator.next();
+            secondaryKey = (String) secondaryEntity.getProperty(foreignKey);
         }
         if (primaryKey.compareTo(secondaryKey) == 0) {
             result.add(secondaryEntity);


### PR DESCRIPTION
The previous code didn't provide the expected output for the following case:
```
primaryKeys = [a, d]
secondaryKeys = [a, b, c, d]

expectedOutput = [a, d]
```

When the while loop ends, the `primaryKeysIter` points to 'd' and the `secondaryKeysIter` points to 'b'.
`secondaryKeysIter.next()` points to 'c' and we didn't add 'd' to the result. 
What we should have done was to keep iterating over `secondaryKeys` until either a match was found or the iterator reaches to end.