### PR TITLE
Export Experiment Data

### DIFF
--- a/src/main/java/com/google/research/bleth/servlets/ReadExperimentStatisticsServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/ReadExperimentStatisticsServlet.java
@@ -18,6 +18,7 @@ import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.Query;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.gson.Gson;
@@ -28,7 +29,6 @@ import com.google.research.bleth.simulator.Schema;
 import com.google.research.bleth.simulator.SimulationMetadata;
 import com.google.research.bleth.simulator.StatisticsState;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -79,9 +79,10 @@ public class ReadExperimentStatisticsServlet extends HttpServlet {
     private static JsonElement serializeObservedIntervalsMap(ImmutableMultimap<Integer, ObservedInterval> observedIntervalsMap) {
         ImmutableMap.Builder<Integer, JsonArray> res = new ImmutableMap.Builder<>();
         for (Integer beaconId : observedIntervalsMap.keySet()) {
-            List<JsonElement> currentBeaconIntervals = new ArrayList<>();
-            observedIntervalsMap.get(beaconId).forEach(interval -> currentBeaconIntervals.add(serializeObservedInterval(interval)));
-            res.put(beaconId, gson.toJsonTree(currentBeaconIntervals).getAsJsonArray());
+            List<JsonElement> serializedBeaconIntervals = observedIntervalsMap.get(beaconId).stream()
+                    .map(ReadExperimentStatisticsServlet::serializeObservedInterval)
+                    .collect(ImmutableList.toImmutableList());
+            res.put(beaconId, gson.toJsonTree(serializedBeaconIntervals).getAsJsonArray());
         }
         return gson.toJsonTree(res.build());
     }

--- a/src/main/java/com/google/research/bleth/servlets/ReadExperimentStatisticsServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/ReadExperimentStatisticsServlet.java
@@ -1,0 +1,97 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.research.bleth.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.Query;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.research.bleth.simulator.ObservedInterval;
+import com.google.research.bleth.simulator.Schema;
+import com.google.research.bleth.simulator.SimulationMetadata;
+import com.google.research.bleth.simulator.StatisticsState;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** A servlet used for reading experiment's statistical data. */
+@WebServlet("/read-experiment-stats")
+public class ReadExperimentStatisticsServlet extends HttpServlet {
+    private static final DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    private static final Gson gson = new Gson(); // Used for json serialization.
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        ImmutableMap.Builder<String, JsonElement> res = new ImmutableMap.Builder<>();
+        String experimentId = request.getParameter("experimentId");
+
+        for (String simulationId : retrieveSimulations(experimentId)) {
+            ImmutableMap.Builder<String, JsonElement> simulationJson = new ImmutableMap.Builder<>(); // Stores metadata and stats.
+            SimulationMetadata metadata = SimulationMetadata.read(simulationId);
+            simulationJson.put(Schema.SimulationMetadata.entityKind, gson.toJsonTree(metadata));
+            Map<String, Double> distancesStats = StatisticsState.readDistancesStats(simulationId);
+            simulationJson.put(Schema.StatisticsState.entityKindDistance, gson.toJsonTree(distancesStats));
+            ImmutableMultimap<Integer, ObservedInterval> observedIntervalsStats = StatisticsState.readIntervalStats(simulationId);
+            simulationJson.put(Schema.StatisticsState.entityKindBeaconsObservedIntervals, serializeObservedIntervalsMap(observedIntervalsStats));
+            res.put(simulationId, gson.toJsonTree(simulationJson.build()));
+        }
+
+        response.setContentType("application/json;");
+        response.getWriter().println(gson.toJson(res.build()));
+    }
+
+    private static List<String> retrieveSimulations(String experimentId) {
+        Query.Filter filterByExperimentId =
+                new Query.FilterPredicate(Schema.ExperimentsToSimulations.experimentId,
+                        Query.FilterOperator.EQUAL, experimentId);
+        Query simulationsQuery = new Query(Schema.ExperimentsToSimulations.entityKind)
+                .setFilter(filterByExperimentId);
+        return datastore.prepare(simulationsQuery)
+                .asList(FetchOptions.Builder.withDefaults())
+                .stream()
+                .map(entity -> (String) entity.getProperty(Schema.ExperimentsToSimulations.simulationId))
+                .collect(Collectors.toList());
+    }
+
+    private static JsonElement serializeObservedIntervalsMap(ImmutableMultimap<Integer, ObservedInterval> observedIntervalsMap) {
+        ImmutableMap.Builder<Integer, JsonArray> res = new ImmutableMap.Builder<>();
+        for (Integer beaconId : observedIntervalsMap.keySet()) {
+            List<JsonElement> currentBeaconIntervals = new ArrayList<>();
+            observedIntervalsMap.get(beaconId).forEach(interval -> currentBeaconIntervals.add(serializeObservedInterval(interval)));
+            res.put(beaconId, gson.toJsonTree(currentBeaconIntervals).getAsJsonArray());
+        }
+        return gson.toJsonTree(res.build());
+    }
+
+    private static JsonElement serializeObservedInterval(ObservedInterval interval) {
+        ImmutableMap.Builder<String, Integer> res = new ImmutableMap.Builder<>();
+        int observed = interval.observed() ? 1 : -1;
+        res.put("start", interval.start());
+        res.put("end", interval.end());
+        res.put("duration", observed * interval.duration()); // positive duration iff observed.
+        return gson.toJsonTree(res.build());
+    }
+}

--- a/src/main/java/com/google/research/bleth/servlets/ReadExperimentStatisticsServlet.java
+++ b/src/main/java/com/google/research/bleth/servlets/ReadExperimentStatisticsServlet.java
@@ -45,11 +45,11 @@ public class ReadExperimentStatisticsServlet extends HttpServlet {
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        ImmutableMap.Builder<String, JsonElement> res = new ImmutableMap.Builder<>();
+        ImmutableMap.Builder<String, JsonElement> res = ImmutableMap.builder();
         String experimentId = request.getParameter("experimentId");
 
         for (String simulationId : retrieveSimulations(experimentId)) {
-            ImmutableMap.Builder<String, JsonElement> simulationJson = new ImmutableMap.Builder<>(); // Stores metadata and stats.
+            ImmutableMap.Builder<String, JsonElement> simulationJson = ImmutableMap.builder(); // Stores metadata and stats.
             SimulationMetadata metadata = SimulationMetadata.read(simulationId);
             simulationJson.put(Schema.SimulationMetadata.entityKind, gson.toJsonTree(metadata));
             Map<String, Double> distancesStats = StatisticsState.readDistancesStats(simulationId);
@@ -77,7 +77,7 @@ public class ReadExperimentStatisticsServlet extends HttpServlet {
     }
 
     private static JsonElement serializeObservedIntervalsMap(ImmutableMultimap<Integer, ObservedInterval> observedIntervalsMap) {
-        ImmutableMap.Builder<Integer, JsonArray> res = new ImmutableMap.Builder<>();
+        ImmutableMap.Builder<Integer, JsonArray> res = ImmutableMap.builder();
         for (Integer beaconId : observedIntervalsMap.keySet()) {
             List<JsonElement> serializedBeaconIntervals = observedIntervalsMap.get(beaconId).stream()
                     .map(ReadExperimentStatisticsServlet::serializeObservedInterval)
@@ -88,7 +88,7 @@ public class ReadExperimentStatisticsServlet extends HttpServlet {
     }
 
     private static JsonElement serializeObservedInterval(ObservedInterval interval) {
-        ImmutableMap.Builder<String, Integer> res = new ImmutableMap.Builder<>();
+        ImmutableMap.Builder<String, Integer> res = ImmutableMap.builder();
         int observed = interval.observed() ? 1 : -1;
         res.put("start", interval.start());
         res.put("end", interval.end());

--- a/src/main/java/com/google/research/bleth/simulator/StatisticsState.java
+++ b/src/main/java/com/google/research/bleth/simulator/StatisticsState.java
@@ -126,9 +126,12 @@ public class StatisticsState {
 
         for (int beaconId = 0; beaconId < beaconsNum; beaconId++) {
             Query intervalsQuery = new Query(Schema.StatisticsState.entityKindBeaconsObservedIntervals);
-            Query.Filter filter = new Query.FilterPredicate(Schema.StatisticsState.beaconId,
+            Query.Filter filterByBeaconId = new Query.FilterPredicate(Schema.StatisticsState.beaconId,
                     Query.FilterOperator.EQUAL, beaconId);
-            intervalsQuery.setFilter(filter);
+            Query.Filter filterBySimulationId = new Query.FilterPredicate(Schema.StatisticsState.simulationId,
+                    Query.FilterOperator.EQUAL, simulationId);
+            Query.CompositeFilter composedQueryFilter = Query.CompositeFilterOperator.and(filterByBeaconId, filterBySimulationId);
+            intervalsQuery.setFilter(composedQueryFilter);
             intervalsQuery.addSort(Schema.StatisticsState.intervalStart, Query.SortDirection.ASCENDING);
             PreparedQuery intervalsPreparedQuery = datastore.prepare(intervalsQuery);
             for (Entity entity : intervalsPreparedQuery.asIterable()) {

--- a/src/main/webapp/WEB-INF/index.yaml
+++ b/src/main/webapp/WEB-INF/index.yaml
@@ -1,0 +1,15 @@
+indexes:
+
+  - kind: BeaconsObservedIntervals
+    ancestor: no
+    properties:
+      - name: beaconId
+      - name: intervalStart
+        direction: asc
+
+  - kind: BeaconsObservedIntervals
+    ancestor: no
+    properties:
+      - name: simulationId
+      - name: intervalStart
+        direction: asc

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -50,6 +50,10 @@
         <servlet-name>ListExperimentsServlet</servlet-name>
         <servlet-class>com.google.research.bleth.servlets.ListExperimentsServlet</servlet-class>
     </servlet>
+    <servlet>
+        <servlet-name>ReadExperimentStatisticsServlet</servlet-name>
+        <servlet-class>com.google.research.bleth.servlets.ReadExperimentStatisticsServlet</servlet-class>
+    </servlet>
 
     <servlet-mapping>
         <servlet-name>ReadBoardStateServlet</servlet-name>
@@ -94,6 +98,10 @@
     <servlet-mapping>
         <servlet-name>ListExperimentsServlet</servlet-name>
         <url-pattern>/list-experiments</url-pattern>
+    </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>ReadExperimentStatisticsServlet</servlet-name>
+        <url-pattern>/read-experiment-stats</url-pattern>
     </servlet-mapping>
 
 </web-app>

--- a/src/main/webapp/js/experiments.js
+++ b/src/main/webapp/js/experiments.js
@@ -88,7 +88,7 @@ function displayExperimentsAsTable(experiments) {
  */
 function createExportDataButton(id, title) {
     var exportDataButton = document.createElement('button');
-    exportDataButton.innerText = 'Export';
+    exportDataButton.innerText = 'Download';
     exportDataButton.addEventListener('click', () => {
         retrieveExperimentStats(id, title);
     });

--- a/src/main/webapp/js/experiments.js
+++ b/src/main/webapp/js/experiments.js
@@ -27,6 +27,34 @@ function retrieveExperiments() {
 }
 
 /**
+ * Fetch url and retrieve a JSON object storing simulations' metadata and statistics.
+ * @param {String} experimentId is the experiment id.
+ * @param {String} experimentTitle is the experiment title.
+ */
+function retrieveExperimentStats(experimentId, experimentTitle) {
+    fetch(`/read-experiment-stats?experimentId=${experimentId}`)
+    .then(response => response.json())
+    .then(stats => { 
+        downloadJson(stats, experimentTitle); 
+    });
+}
+
+/**
+ * Download a JSON object as a .json file.
+ * @param {Object} exportObj is the JSON object to download.
+ * @param {String} exportName is the name of the downloaded file (followed by '.json').
+ */
+function downloadJson(exportObj, exportName) {
+    var data = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(exportObj));
+    var anchor = document.createElement('a');
+    anchor.setAttribute("href", data);
+    anchor.setAttribute("download", exportName + ".json");
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  }
+
+/**
  * Given a json object storing experiments, write all data to an html table.
  * @param {Object} experiments is an object storing experiments' unique id and title.
  */
@@ -46,7 +74,7 @@ function displayExperimentsAsTable(experiments) {
         const title = experiments[id];
         var row = table.insertRow(-1);
         const cell = row.insertCell(0);
-        const exportDataButton = createExportDataButton(id); 
+        const exportDataButton = createExportDataButton(id, title); 
         cell.appendChild(exportDataButton);
         row.insertCell(1).innerHTML = id;
         row.insertCell(2).innerHTML = title;
@@ -56,12 +84,13 @@ function displayExperimentsAsTable(experiments) {
 /**
  * Create a button for exporting raw intervals data.
  * @param {String} id is the experiment id to export.
+ * @param {String} title is the experiment title to export.
  */
-function createExportDataButton(id) {
+function createExportDataButton(id, title) {
     var exportDataButton = document.createElement('button');
     exportDataButton.innerText = 'Export';
     exportDataButton.addEventListener('click', () => {
-        // TODO: fetch interval stats and download file.
+        retrieveExperimentStats(id, title);
     });
     return exportDataButton;
 }


### PR DESCRIPTION
- Implementation of `ReadExperimentStatisticsServlet` for reading statistics of all simulation associated with provided `experimentId` and write to the response as JSON.
- Implementation of 'Download' button for downloading the experiment data as a .json file.
- Add `index.yaml` file for creation of indexes for supporting queries with multiple filters (on both `beaconId` and `simulationId` properties) on the `BeaconsObservedIntervals` entity.